### PR TITLE
chore: 깃허브 인증 파일 생성 과정 추가

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -33,6 +33,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Set up github credential
+        run: |
+          echo "machine github.com" > ~/.netrc
+          echo "login github-actions" >> ~/.netrc
+          echo "password $ACTIONS_TOKEN" >> ~/.netrc
+        env:
+          ACTIONS_TOKEN: ${{ secrets.ACTIONS_TOKEN }}
+
       - name: Build and push
         uses: docker/build-push-action@v3
         with:


### PR DESCRIPTION

## Changes

- build-push 과정에서 private레포를 패키지로 설치하는 경우에 깃허브 토큰값이 저장된 파일이 필요합니다. 이 파일을 생성하는 과정을 추가하여 이 ci를 이용하는 곳에서 추가적인 깃허브 인증 과정이 필요 없게끔 했습니다.
- 토큰은 깃허브 시크릿에 organization단에서 설정하여 관리하고 있습니다. `${{ secrets.ACTIONS_TOKEN }}`로 접근하여 사용할 수 있습니다.

## Test


## Task Link

다음 레퍼런스를 참고했습니다.
https://gist.github.com/technoweenie/1072829
