### PR TITLE
feat: auto release workflow 추가

### DIFF
--- a/.github/workflows/auto-release-on-pyproject-version-update.yaml.yaml
+++ b/.github/workflows/auto-release-on-pyproject-version-update.yaml.yaml
@@ -1,4 +1,4 @@
-name: Automated Release Process
+name: Create Release on Pyproject Version Change
 # Automatically create a release when a version specified in a pyproject.toml is changed.
 
 on:

--- a/.github/workflows/github-auto-release.yaml
+++ b/.github/workflows/github-auto-release.yaml
@@ -1,0 +1,48 @@
+name: Automated Release Process
+# Automatically create a release when a version specified in a pyproject.toml is changed.
+
+on:
+  workflow_call:
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Determine Version Change
+        id: version_check
+        run: |
+          VERSION="v$(poetry version -s)"
+          echo "Current version: $VERSION"
+
+          LATEST_RELEASE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r '.tag_name')
+          echo "Latest release version: $LATEST_RELEASE"
+
+          if [ "$VERSION" != "$LATEST_RELEASE" ]; then
+            echo "Version has changed."
+            echo "version_changed=true" >> $GITHUB_OUTPUT
+            echo "new_version=$VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "No version change detected."
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        if: steps.version_check.outputs.version_changed == 'true'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version_check.outputs.new_version }}
+          generate_release_notes: True


### PR DESCRIPTION
**리뷰어가 작업내용을 이해하기 쉽도록 아래내용을 상세히 작성해주세요.**

## Changes

- pyproject.toml에 명시된 버전이 변경되었을 때, github release를 자동으로 생성하는 reusable workflow를 추가하였습니다.

## Test

> **💡** _진행한 테스트에 대해서 구체적으로 작성해주세요._

- 개인 레포에서 테스트를 진행하였습니다. 

## Task Link

> **💡** _관련 페이지 링크를 작성해주세요._


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> # Automated Release Process
> 
> ## TL;DR
> This pull request introduces an automated release process for the project. The new workflow will automatically create a release when a version specified in a `pyproject.toml` file is changed.
> 
> ## What changed
> A new GitHub Actions workflow file named `github-auto-release.yaml` has been added to the `.github/workflows` directory. This workflow is triggered on a workflow call and runs on the latest version of Ubuntu.
> 
> The workflow checks out the repository, sets up Python, installs Poetry, and determines if the version has changed. If a version change is detected, it creates a new release using the `softprops/action-gh-release` action.
> 
> ## How to test
> To test this change, you can make a change to the version specified in the `pyproject.toml` file and push the change to the repository. The workflow should be triggered and a new release should be created if the version has changed.
> 
> ## Why make this change
> This change automates the release process, making it easier to manage and track version changes. It also ensures that a new release is created whenever the version changes, keeping the releases up-to-date with the latest changes.
</details>