### PR TITLE
fix: update output variable names in staging-image-tag workflow

### DIFF
--- a/.github/workflows/staging-image-tag.yaml
+++ b/.github/workflows/staging-image-tag.yaml
@@ -4,17 +4,17 @@ on:
     outputs:
       image-tag:
         description: "IMAGE_TAG FROM COMMIT SHA"
-        value: ${{ jobs.staging-image-tag.outputs.SHA }}
+        value: ${{ jobs.staging-image-tag.outputs.IMAGE_TAG }}
 
 jobs:
   staging-image-tag:
     runs-on: ubuntu-latest
     outputs:
-      SHA: ${{ steps.SHA.outputs.SHA }}
+      IMAGE_TAG: ${{ steps.IMAGE_TAG.outputs.IMAGE_TAG }}
 
     steps:
       - uses: actions/checkout@v3
       - uses: benjlevesque/short-sha@v1.2
         id: short-sha
-      - id: SHA
-        run: echo "SHA=${{ steps.short-sha.outputs.sha }}" >> $GITHUB_OUTPUT
+      - id: IMAGE_TAG
+        run: echo "IMAGE_TAG=staging-${{ steps.short-sha.outputs.sha }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION

## Changes

- 스테이징 환경의 이미지 태그 형식을 변경했습니다
- 기존에는 커밋 SHA만 사용했으나, 이제 'staging-' 접두사를 추가하여 `staging-{SHA}` 형식으로 변경했습니다
- k8s에 들어갈때 commitsha가 숫자로만 구성되었을 때 문제가 발생하는 경우가 있어 이를 방지하기 위함입니다
- 부가적으로 이미지 태그에 'staging-' 접두사를 추가함으로써 환경을 명확히 구분할 수 있어 운영 관리가 용이해집니다

