### PR TITLE
ci: pin setup-uv release tag

### DIFF
--- a/.github/workflows/notify-discord.yaml
+++ b/.github/workflows/notify-discord.yaml
@@ -25,7 +25,7 @@ jobs:
           # https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#job-context
           repository: ${{ job.workflow_repository }}
           ref: ${{ job.workflow_sha }}
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock

--- a/.github/workflows/update-k8s-mainifest.yaml
+++ b/.github/workflows/update-k8s-mainifest.yaml
@@ -63,7 +63,7 @@ jobs:
           path: alpha-actions
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
           cache-dependency-glob: alpha-actions/uv.lock


### PR DESCRIPTION
## 변경 이유

- `astral-sh/setup-uv@v8` major alias ref가 없어 workflow에서 `Unable to resolve action` 오류가 발생했습니다.
- `setup-uv` 최신 릴리스 태그인 `v8.2.0`은 존재하므로 해당 태그로 명시해 action resolve를 안정화합니다.

## 변경사항

- `notify-discord.yaml`의 `astral-sh/setup-uv@v8`을 `astral-sh/setup-uv@v8.2.0`으로 변경했습니다.
- `update-k8s-mainifest.yaml`의 `astral-sh/setup-uv@v8`을 `astral-sh/setup-uv@v8.2.0`으로 변경했습니다.
- `.github/workflows`의 모든 `uses:` action ref가 실제 tag/branch로 resolve되는지 확인했습니다.

## 테스트

- [x] `uv run pytest`
- [x] workflow YAML parse
- [x] `actionlint .github/workflows/*.yaml`
- [x] all workflow `uses:` refs resolve via `git ls-remote`
- [x] `git diff --check`

## Tags

#github-actions #uv

## 태스크 링크

- N/A
